### PR TITLE
Simplify log likelihoods and add placeholder items

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Notes:
 
 * This repository is early-stage! (The main functionality should be working though.)
 * I'm looking for collaborators. If you're interested please contact me!
+* I also appreciate feedback and currently the chance is high that I will implement extra features you might ask for, especially if these features increase usability (and fit the roadmap).
 
 
 ## Usage

--- a/perspectival/dataset.py
+++ b/perspectival/dataset.py
@@ -7,6 +7,50 @@ class Item(BaseModel):
     prompt: str
     options: List[str]
 
+    def get_statements(self) -> List[str]:
+        """Get a list of statements corresponding to the different options.
+
+        Log likelihoods should be computed for these statements."""
+        statements = [
+            (
+                self.prompt
+                + (
+                    " "
+                    if (not self.prompt.endswith(" ") and not option.startswith(" "))
+                    else ""
+                )
+                + option
+            ).strip()
+            for option in self.options
+        ]
+        return statements
+
+    def get_continuation_prompt(self) -> str:
+        """Get a prompt that is used as input to generate continuations."""
+        return self.prompt
+
+
+class PlaceholderItem(Item):
+    placeholder: str = "_"
+
+    def get_statements(self) -> List[str]:
+        """Get a list of statements corresponding to the different options.
+
+        Log likelihoods should be computed for these statements."""
+        statements = []
+        for option in self.options:
+            statement = self.prompt.replace(self.placeholder, option)
+
+            # Remove extra whitespaces
+            statement = statement.strip()
+
+            statements.append(statement)
+        return statements
+
+    def get_continuation_prompt(self) -> str:
+        """Get a prompt that is used as input to generate continuations."""
+        raise ValueError("Continuation doesn't work for placeholder items!")
+
 
 class Dataset(BaseModel):
     """Class to handle datasets"""

--- a/perspectival/experiment.py
+++ b/perspectival/experiment.py
@@ -142,6 +142,22 @@ class Experiment:
             comparison_features=comparison_features,
         )
 
+    def compute_model_choices(self, model: Model) -> ModelChoices:
+        """Compute choices and option log likelihoods for the given model.
+
+        Features are registered so they can be re-used.
+        If any of these features already exists, computation is skipped."""
+        model_choices = self.get_feature("ModelChoices", model=model.name)
+        if model_choices is None:
+            lls = self.get_feature("OptionLogLikelihood", model=model.name)
+            if lls is None:
+                lls = OptionLogLikelihood.compute(self.dataset, model=model)
+                self.register_feature(lls)
+
+            model_choices = ModelChoices.compute(lls)
+            self.register_feature(model_choices)
+        return model_choices
+
     def compute_correctness(self, models: List[Model]):
         ground_truth = self.get_feature("GroundTruth")
         if ground_truth is None:
@@ -151,15 +167,7 @@ class Experiment:
             )
 
         for model in models:
-            model_choices = self.get_feature("ModelChoices", model=model.name)
-            if model_choices is None:
-                lls = self.get_feature("OptionLogLikelihood", model=model.name)
-                if lls is None:
-                    lls = OptionLogLikelihood.compute(self.dataset, model=model)
-                    self.register_feature(lls)
-
-                model_choices = ModelChoices.compute(lls)
-                self.register_feature(model_choices)
+            model_choices = self.compute_model_choices(model=model)
             self.register_feature(
                 PredictionCorrectness.compute(
                     model_choices=model_choices, ground_truth=ground_truth
@@ -271,14 +279,18 @@ class Experiment:
             feature_list = self.get_features(feature_name)
             for feature in feature_list:
                 if isinstance(feature, ItemFeature):
-                    print(feature_name, feature.values[item_ix])
+                    print(f"{feature_name}: {feature.values[item_ix]}")
                 elif isinstance(feature, ModelFeature):
-                    print(feature_name, feature.model, feature.values[item_ix])
+                    print(
+                        f"{feature_name} - {feature.model}: {feature.values[item_ix]}"
+                    )
                 elif isinstance(feature, ComparisonFeature):
-                    print(feature_name, feature.models, feature.values[item_ix])
+                    print(
+                        f"{feature_name} - {feature.models}: {feature.values[item_ix]}"
+                    )
                 else:
                     print("Warning: Unknown feature type!")
-                    print(feature_name, feature.values[item_ix])
+                    print(f"{feature_name}: {feature.values[item_ix]}")
 
     def display_items(
         self,

--- a/perspectival/experiment.py
+++ b/perspectival/experiment.py
@@ -34,6 +34,7 @@ class Experiment:
         self,
         name,
         dataset,
+        *,
         item_features=None,
         model_features=None,
         comparison_features=None,
@@ -215,6 +216,7 @@ class Experiment:
     def sample(
         self,
         num: Optional[int] = None,
+        *,
         sampling_method: str = "random",
         ordering_scores: Optional[List[float]] = None,
         mask: Optional[List[bool]] = None,

--- a/perspectival/inspect.py
+++ b/perspectival/inspect.py
@@ -139,6 +139,7 @@ def inspect_texts(
     texts: str,
     models: Tuple[Transformer, Transformer],
     mode: str = "log_likelihoods",
+    *,
     color_map_name: str = "Blues",
     max_color: float = 0.7,  # Ensure lighter colors
     top_k: int = 5,

--- a/perspectival/interfaces.py
+++ b/perspectival/interfaces.py
@@ -72,7 +72,21 @@ class Model(metaclass=abc.ABCMeta):
     name: str
 
     @abc.abstractmethod
-    def compute_option_log_likelihoods(self, items: List[Item]):
+    def compute_option_log_likelihoods(self, items: List[Item]) -> List[List[float]]:
+        """Take a list of items and return log likelihoods for the different
+        item options.
+
+        Returns a list of item results, where each item result is a list of
+        log likelihoods corresponding to the different options included in the item.
+        (That is, index [i][j] contains the log likelihood of the j-th option
+        of the i-th item.)
+
+        Note that interpreting absolute values of log likelihoods can be misleading
+        because depending on the model implementation, log likelihoods from the
+        prompt might be included.
+        Therefore, avoid directly comparing option log likelihoods from
+        different models, but rather compare how ranks of different options
+        differ from one model to another."""
         raise NotImplementedError()
 
     @abc.abstractmethod
@@ -81,4 +95,5 @@ class Model(metaclass=abc.ABCMeta):
         items: List[Item],
         **kwargs,
     ) -> List[str]:
+        """Take a list of items and use the model to continue the given prompts."""
         raise NotImplementedError()

--- a/perspectival/model.py
+++ b/perspectival/model.py
@@ -16,6 +16,7 @@ def generate(
     transformer,
     tokenizer,
     beginning: str,
+    *,
     temperature: float = 0,
     max_new_tokens: int = 64,
     do_sample=False,
@@ -76,6 +77,7 @@ class Transformer(Model):
     def __init__(
         self,
         model_name,
+        *,
         lazy_loading: bool = True,
         model_kwargs: Optional[dict] = None,
         tokenizer_kwargs: Optional[dict] = None,

--- a/perspectival/model.py
+++ b/perspectival/model.py
@@ -102,10 +102,6 @@ class Transformer(Model):
         if self.model_name.startswith("apple/OpenELM"):
             # tokenizer_name = 'NousResearch/Llama-2-7b-hf'
             tokenizer_name = "meta-llama/Llama-2-7b-hf"
-        elif self.model_name == "mistralai/Mistral-7B-Instruct-v0.3":
-            # Mistral team recommends using the mistral_common tokenizer
-            # (Note from HuggingFace model page, status Jul 3, 24)
-            tokenizer_name = "mistral_common"
         else:
             tokenizer_name = self.model_name
         tokenizer = AutoTokenizer.from_pretrained(
@@ -152,7 +148,7 @@ class Transformer(Model):
         self,
         items: List[Item],
         **kwargs,
-    ) -> List[float]:
+    ) -> List[List[float]]:
         model, tokenizer = self.get_model_and_tokenizer()
 
         # Initialize return list
@@ -240,7 +236,7 @@ class SimpleTransformer(Transformer):
         items: List[Item],
         subtract_prompt: bool = False,
         **kwargs,
-    ) -> List[float]:
+    ) -> List[List[float]]:
         model, tokenizer = self.get_model_and_tokenizer()
 
         log_likelihoods = []

--- a/perspectival/model.py
+++ b/perspectival/model.py
@@ -102,6 +102,10 @@ class Transformer(Model):
         if self.model_name.startswith("apple/OpenELM"):
             # tokenizer_name = 'NousResearch/Llama-2-7b-hf'
             tokenizer_name = "meta-llama/Llama-2-7b-hf"
+        elif self.model_name == "mistralai/Mistral-7B-Instruct-v0.3":
+            # Mistral team recommends using the mistral_common tokenizer
+            # (Note from HuggingFace model page, status Jul 3, 24)
+            tokenizer_name = "mistral_common"
         else:
             tokenizer_name = self.model_name
         tokenizer = AutoTokenizer.from_pretrained(
@@ -133,7 +137,10 @@ class Transformer(Model):
         print("Computing text continuations ...")
         for item in tqdm(items):
             text = generate(
-                transformer=model, tokenizer=tokenizer, beginning=item.prompt, **kwargs
+                transformer=model,
+                tokenizer=tokenizer,
+                beginning=item.get_continuation_prompt(),
+                **kwargs,
             )
             # Only consider the part after the given text
             text = text[len(item.prompt) :]
@@ -153,16 +160,7 @@ class Transformer(Model):
 
         print("Computing option log likelihoods ...")
         for item in tqdm(items):
-            input_texts = [
-                item.prompt
-                + (
-                    " "
-                    if (not item.prompt.endswith(" ") and not option.startswith(" "))
-                    else ""
-                )
-                + option
-                for option in item.options
-            ]
+            input_texts = item.get_statements()
 
             # Tokenize the combined texts
             encoded_inputs = tokenizer(
@@ -177,21 +175,16 @@ class Transformer(Model):
             with torch.no_grad():
                 logits = model(**encoded_inputs, **kwargs).logits
 
-            # Ignore the log probs at the beginning
-            prompt_length = (
-                len(tokenizer(item.prompt, add_special_tokens=False)["input_ids"]) - 1
-            )
-
             # Calculate log probabilities from the logits for each token
             log_probs = F.log_softmax(logits, dim=-1)
 
             if tokenizer.padding_side == "right":
-                # Need to offset by one since last position contains prediction
+                # Need to offset by one since previous position contains prediction
                 # for current token
-                log_probs = log_probs[:, prompt_length - 1 : -1]
+                log_probs = log_probs[:, :-1]
 
-                input_ids = encoded_inputs["input_ids"][:, prompt_length:]
-                attention_mask = encoded_inputs["attention_mask"][:, prompt_length:]
+                input_ids = encoded_inputs["input_ids"][:, 1:]
+                attention_mask = encoded_inputs["attention_mask"][:, 1:]
 
                 # Get log probabilities of actual tokens
                 token_log_probs = log_probs.gather(2, input_ids.unsqueeze(-1)).squeeze(
@@ -204,8 +197,6 @@ class Transformer(Model):
                 )
 
             else:
-                prompt_length += 1  # BOS token
-
                 # Offset by one since likelihoods refer to next position
                 log_probs = log_probs[:, :-1]
                 input_ids = encoded_inputs["input_ids"][:, 1:]
@@ -214,7 +205,6 @@ class Transformer(Model):
                 # Note: We don't offset the attention mask to exclude
                 # likelihoods of BOS tokens for padded sequences
                 # (which can be quite low)
-                # attention_mask = attention_mask[:, 1:]
                 attention_mask = attention_mask[:, :-1]
 
                 token_log_probs = log_probs.gather(2, input_ids.unsqueeze(-1)).squeeze(
@@ -226,10 +216,7 @@ class Transformer(Model):
 
                 # Note: Setting offsets to 0 leads to computing log likelihoods
                 # over the whole sequence including the prompt (useful for debugging)
-                offsets = (
-                    np.argmax(attention_mask.detach().cpu().numpy(), axis=1)
-                    + prompt_length
-                )
+                offsets = np.argmax(attention_mask.detach().cpu().numpy(), axis=1)
                 masked_log_probs = [
                     lls[offset:] for lls, offset in zip(masked_log_probs, offsets)
                 ]
@@ -251,7 +238,7 @@ class SimpleTransformer(Transformer):
     def compute_option_log_likelihoods(
         self,
         items: List[Item],
-        subtract_prompt: bool = True,
+        subtract_prompt: bool = False,
         **kwargs,
     ) -> List[float]:
         model, tokenizer = self.get_model_and_tokenizer()
@@ -260,16 +247,7 @@ class SimpleTransformer(Transformer):
 
         print("Computing option log likelihoods ...")
         for item in tqdm(items):
-            input_texts = [
-                item.prompt
-                + (
-                    " "
-                    if (not item.prompt.endswith(" ") and not option.startswith(" "))
-                    else ""
-                )
-                + option
-                for option in item.options
-            ]
+            input_texts = item.get_statements()
 
             if subtract_prompt:
                 # .rstrip() is to avoid that a whitespace token with low likelihood

--- a/perspectival/util.py
+++ b/perspectival/util.py
@@ -1,0 +1,25 @@
+from typing import List
+
+
+def truncate_at_stopping_strings(
+    text: str, stopping_strings: List[str], look_forward: bool = False
+):
+    """Return the part of `text` until any of the substrings in `stopping_strings`
+    occurred.
+
+    Arguments:
+    :text: Text to truncate
+    :stopping_strings: List of strings. The text is truncated at the earliest
+        occurrence of any of these strings
+    :look_forward: If True, the stopping string is not included in the truncated text"""
+    string_positions = [text.find(s) for s in stopping_strings]
+    stopping_positions = [
+        text.find(stopping_string) + (len(stopping_string) if not look_forward else 0)
+        for pos, stopping_string in zip(string_positions, stopping_strings)
+        if pos >= 0
+    ]
+    if len(stopping_positions) > 0:
+        stopping_position = min(stopping_positions)
+    else:
+        stopping_position = None
+    return text[:stopping_position]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -16,6 +16,14 @@ from perspectival.model import compute_token_log_likelihood
             ),
             2,
         ),
+        (Item(id=3, prompt="", options=["One of the blanket", "The sky is blue."]), 0),
+        (
+            Item(
+                id=4, prompt="", options=["Hello world!", "Bello world!", "Hello girl!"]
+            ),
+            1,
+        ),
+        (Item(id=5, prompt="", options=["I am", "I go", "The am"]), 2),
         # Add more test cases here as tuples of (Item, unlikely_index)
     ]
 )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,27 @@
+import pytest
+
+from perspectival.util import truncate_at_stopping_strings
+
+
+TEST_TEXT = "This is a text! How you doin? Good. Wow!"
+
+
+@pytest.mark.parametrize(
+    "text, stopping_strings, look_forward, result",
+    [
+        (TEST_TEXT, ["text! How", "!", "."], False, "This is a text!"),
+        (TEST_TEXT, ["text! How", "!", "."], True, "This is a "),
+        (TEST_TEXT, ["7", "\n", "texti"], False, TEST_TEXT),
+        (TEST_TEXT, ["7", "\n", "texti"], True, TEST_TEXT),
+        (" Hi!", [" "], False, " "),
+        (" Hi!", [" "], True, ""),
+    ],
+)
+def test_truncate_at_stopping_strings(
+    text,
+    stopping_strings,
+    look_forward,
+    result,
+):
+    truncated_text = truncate_at_stopping_strings(text, stopping_strings, look_forward)
+    assert truncated_text == result


### PR DESCRIPTION
- When computing option log likelihoods, we no longer subtract the initial part, as this caused some problems
(e.g. effects of merging tokens leading to negative overall likelihoods in some cases).
- Placeholder items can be used, where options don't come in the end but are inserted anywhere in the text.